### PR TITLE
Fix page properties detection broken by AEM 6.5 LTS ContentFrame change

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
-    <release version="2.1.0" date="not released">
+    <release version="2.1.1" date="not released">
       <action type="fix" dev="bartessers">
         Fix page properties detection broken by AEM 6.5 LTS ContentFrame change
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="2.1.0" date="not released">
+      <action type="fix" dev="bartessers">
+        Fix page properties detection broken by AEM 6.5 LTS ContentFrame change
+      </action>
+    </release>
+
     <release version="2.1.0" date="2026-08-17">
       <action type="update" dev="sseifert">
         Switch to AEM 6.5.24 as minimum version (also compatible with AEM 6.6.2 / AEM 6.5 LTS SP2 and AEMaaCS).

--- a/changes.xml
+++ b/changes.xml
@@ -24,9 +24,9 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
-    <release version="2.1.1" date="not released">
-      <action type="fix" dev="bartessers">
-        Fix page properties detection broken by AEM 6.5 LTS ContentFrame change
+    <release version="2.1.2" date="not released">
+      <action type="fix" dev="bartessers" issue="33">
+        Link Plugin: Make content path detection more fail-safe when ContentFrame is present but no current location.
       </action>
     </release>
 

--- a/src/main/webapp/app-root/clientlibs/rte.plugins/js/linkPlugin.js
+++ b/src/main/webapp/app-root/clientlibs/rte.plugins/js/linkPlugin.js
@@ -73,7 +73,7 @@
     detectCurrentPagePath: function() {
 
       // try get get current page path from ContentFrame (works for IPE and in component edit dialogs)
-      if (Granite && Granite.author && Granite.author.ContentFrame) {
+      if (Granite && Granite.author && Granite.author.ContentFrame && Granite.author.ContentFrame.currentLocation()) {
         return Granite.author.ContentFrame.getContentPath();
       }
 

--- a/src/main/webapp/app-root/clientlibs/rte.plugins/js/linkPlugin.js
+++ b/src/main/webapp/app-root/clientlibs/rte.plugins/js/linkPlugin.js
@@ -71,8 +71,12 @@
      * Detects the current page path. May return null.
      */
     detectCurrentPagePath: function() {
-
-      // try get get current page path from ContentFrame (works for IPE and in component edit dialogs)
+      /**
+       * try get get current page path from ContentFrame (works for IPE and in component edit dialogs)
+       * As of AEM 6.5 LTS the ContentFrame is loaded in the page properties dialog but it has no location set.
+       * We need to check if the location is set on the ContentFrame because getContentPath executes
+       * the "replace"-method on the location.
+       */
       if (Granite && Granite.author && Granite.author.ContentFrame && Granite.author.ContentFrame.currentLocation()) {
         return Granite.author.ContentFrame.getContentPath();
       }


### PR DESCRIPTION
As of AEM 6.5 LTS, `Granite.author.ContentFrame` is now also loaded when the page properties dialog is open — previously it was absent there. Because of this, the check in `linkPlugin#detectCurrentPagePath` that used the absence of Granite.author.ContentFrame to detect the page properties dialog is no longer sufficient.

This PR adds an additional check for whether the content frame has a location.

Without this fix, `Granite.author.ContentFrame.getContentPath()` throws an error in the page properties dialog (since location is missing there), which in turn prevents the rich text editor from rendering correctly.

Fixes #33 